### PR TITLE
Fix warning about vm_enable being set improperly.

### DIFF
--- a/known-issues.txt
+++ b/known-issues.txt
@@ -6,7 +6,6 @@ Known vmrc Issues
    rc script: TEST
 4. bhyveload has a 31 character VM name limit
 5. "detached" VM's do not auto-cleanup
-6. /etc/rc: WARNING: $vm_enable is not set properly - see rc.conf(5).
 
 Thanks!
 

--- a/vm
+++ b/vm
@@ -1359,6 +1359,9 @@ echo Reading /usr/local/etc/vm.conf
 		{ echo /usr/local/etc/vm.conf failed to source. Exiting ; exit 1 ; }
 
 load_rc_config $name
+
+: ${vm_enable:="NO"}
+
 run_rc_command "$vm_cmd"
 
 ########################################################################


### PR DESCRIPTION
Fixes the vm_enable warning issue with the solution from the porter's handbook.
