### PR TITLE
Fixes to OpenBSD template files

### DIFF
--- a/templates/obsd55amd64iso
+++ b/templates/obsd55amd64iso
@@ -31,7 +31,7 @@ iso_grub_d="-d $host_vmdir/$1"
                          # ISO mode grub-bhyve -d directive
                          # -d $host_vmdir/$1 for local or -d /grub/ for VM
 iso_grub_r=""            # VM device where to find grub.cfg i.e. -r cd0,msdos1
-img_grub_cfg="kopenbsd -h com0 (cd0)/5.5/amd64/bsd.rd\nboot" 
+img_grub_cfg="kopenbsd -h com0 -r sd0a (hd0,openbsd1)/bsd\nboot" 
                          # \n separated grub.cfg (required for GRUB img boot)
 img_grub_d="-d $host_vmdir/$1"
                          # IMG mode grub-bhyve -d directive 

--- a/templates/obsd56amd64_zvol_iso
+++ b/templates/obsd56amd64_zvol_iso
@@ -31,7 +31,7 @@ iso_grub_d="-d $host_vmdir/$1"
                          # ISO mode grub-bhyve -d directive
                          # -d $host_vmdir/$1 for local or -d /grub/ for VM
 iso_grub_r=""            # VM device where to find grub.cfg i.e. -r cd0,msdos1
-img_grub_cfg="kopenbsd -h com0 -r sd0a (hd0,openbsd1)/bsd.mp\nboot"
+img_grub_cfg="kopenbsd -h com0 -r sd0a (hd0,openbsd1)/bsd\nboot"
                          # \n separated grub.cfg (required for GRUB img boot)
 img_grub_d="-d $host_vmdir/$1"
                          # IMG mode grub-bhyve -d directive 

--- a/templates/obsd56amd64iso
+++ b/templates/obsd56amd64iso
@@ -31,7 +31,7 @@ iso_grub_d="-d $host_vmdir/$1"
                          # ISO mode grub-bhyve -d directive
                          # -d $host_vmdir/$1 for local or -d /grub/ for VM
 iso_grub_r=""            # VM device where to find grub.cfg i.e. -r cd0,msdos1
-img_grub_cfg="kopenbsd -h com0 -r sd0a (hd0,openbsd1)/bsd.mp\nboot"
+img_grub_cfg="kopenbsd -h com0 -r sd0a (hd0,openbsd1)/bsd\nboot"
                          # \n separated grub.cfg (required for GRUB img boot)
 img_grub_d="-d $host_vmdir/$1"
                          # IMG mode grub-bhyve -d directive 


### PR DESCRIPTION
This fixes several issues in the OpenBSD templates files. The first is an copy/paste error and the second two are changing the grub-bhyve command from "boot bsd.mp" to "boot bsd" since the kernel is named to bsd by the installer whether it is actually GENERIC or GENERIC.MP.
