### PR TITLE
Consistency fix for vm_os_type definition

### DIFF
--- a/templates/dyn_arch20140801amd64iso
+++ b/templates/dyn_arch20140801amd64iso
@@ -2,7 +2,7 @@
 # mkvm.sh copies this to /usr/local/vmrc/vm/<vmname><vmid>.conf
 
 # VM global variables used by both provisioning and at runtime
-vm_os_type="grub"        # "freebsd" or "other" (required)
+vm_os_type="grub"        # "freebsd" or "grub" (required)
 vm_dev_type="img"        # (disk) "img", (RAM) "malloc", "zvol" or "device"
 vm_dev_root=""           # p2, p3, s1a etc. (required for FreeBSD fsck & mount)
 vm_dev_fs=""             # "ufs" or "zfs" (for FreeBSD UFS fsck or provisioning)


### PR DESCRIPTION
This fix causes the vm_os_type definition of "grub" to also be mentioned in the comment on the same line rather than the previous value of "other."
