### PR TITLE
Replace the `ps ax | grep ...` call with pkill

### DIFF
--- a/vm
+++ b/vm
@@ -607,7 +607,7 @@ f_stop() # $host_vmdir $vm_name ($1)
 	echo
 	echo Sending ACPI shutdown to $1
 
-ps ax | grep $1 | awk '{print $1 }' | xargs kill -TERM > /dev/null 2>&1
+pkill -TERM -f $1 > /dev/null 2>&1
 sleep 10
 # Need to see if a delay is needed etc. for the cleanest possible shutdown.
 #	/usr/sbin/bhyvectl --force-poweroff --vm=$vm_names


### PR DESCRIPTION
Using the pipes has the nasty side effect of killing the service command
itself. Having a guest called openbsd0 these are the processes killed:

```
    root@i5:~ # ps ax | grep openbsd0
    33916  2  Is+      0:00.01 csh -c /bin/sh /usr/local/etc/rc.d/vm onerun openbsd0
    33920  2  I+       0:00.01 /bin/sh /usr/local/etc/rc.d/vm onerun openbsd0
    33955  2  S+       0:13.20 bhyve: openbsd0 (bhyve)
    34114  3  S+       0:00.00 grep --color openbsd0
```

Killing the grep process stops the execution of the f_stop function
before cleaning up /dev/vmm and the tap interfaces.

```
   root@i5:~ # tmux ls
   openbsd0: 1 windows (created Fri Oct 31 01:14:20 2014) [159x69]
   root@i5:~ # service vm onestop openbsd0

   Stopping openbsd0

   Sending ACPI shutdown to openbsd0
   Terminated
   root@i5:~ # pgrep -lf bhyve
   root@i5:~ # ls /dev/vmm
   openbsd0
```

This issue was not present when running the stop directive without an
argument (service vm onestop).

After this patch, and using the pkill command I didn't notice any
leftovers after the stop command, and it didn't change the behavior of
`service vm onestop`, though I only have one guest on this host, and I
didn't try the loop.
