### PR TITLE
Ubuntutemplate

### DIFF
--- a/templates/ubuntu1404amd64iso
+++ b/templates/ubuntu1404amd64iso
@@ -29,8 +29,10 @@ iso_grub_d=""            # ISO mode grub-bhyve -d directive
                          # -d $host_vmdir/$1 for local or -d /grub/ for VM
 iso_grub_r="-r cd0"      # VM device where to find grub.cfg i.e. -r cd0,msdos1
 img_grub_cfg=""          # \n separated grub.cfg (required for GRUB img boot)
-img_grub_d="-d /grub"    # IMG mode grub-bhyve -d directive
+img_grub_d=""            # IMG mode grub-bhyve -d directive
                          # -d $host_vmdir/$1 for local or -d /grub/ for VM
+                         # LVM installs should use "-d /grub" while
+                         # ext4 installs should use the default ""
 img_grub_r="-r hd0,msdos1"
                          # VM device where to find grub.cfg i.e. -r hd0,msdos1
 

--- a/templates/ubuntu1404amd64iso
+++ b/templates/ubuntu1404amd64iso
@@ -29,7 +29,7 @@ iso_grub_d=""            # ISO mode grub-bhyve -d directive
                          # -d $host_vmdir/$1 for local or -d /grub/ for VM
 iso_grub_r="-r cd0"      # VM device where to find grub.cfg i.e. -r cd0,msdos1
 img_grub_cfg=""          # \n separated grub.cfg (required for GRUB img boot)
-img_grub_d=""            # IMG mode grub-bhyve -d directive 
+img_grub_d="-d /grub"    # IMG mode grub-bhyve -d directive
                          # -d $host_vmdir/$1 for local or -d /grub/ for VM
 img_grub_r="-r hd0,msdos1"
                          # VM device where to find grub.cfg i.e. -r hd0,msdos1


### PR DESCRIPTION
I am not sure how you feel about trailing whitespace; my editor automatically trimmed that. I am also something of a git newbie so this PR includes 2 commits that could easily be 1. I'm certainly willing to redo this if there is a better way.

Basically, I've found that if you use the defaults in the ubuntu template to install ubuntu as non-LVM, grub-bhyve can find the default grub config. But if you install ubuntu with LVM, you need to set img_grub_d to "-d /grub" to find the installed ubuntu's grub config. I prefer this to setting img_grub_cfg since kernel upgrades would require changing img_grub_cfg as ubuntu kernel and initrd files include their kernel version.