### PR TITLE
add generic vm_device to device.map in f_load instead of assuming .img

### DIFF
--- a/vm
+++ b/vm
@@ -292,7 +292,7 @@ f_info "Verifying if $1 is already loaded"
 
 # Note that we do not set the iso as $vm_device because grub will handle this
 	f_info "Creating $host_vmdir/$1/device.map"
-	echo "(hd0) $host_vmdir/$1/${1}.img" > $host_vmdir/$1/device.map 
+	echo "(hd0) $vm_device" > $host_vmdir/$1/device.map
 
 # The ISO *should* be there but this check will avoid breakage
 	f_info "Checking if we are in ISO boot mode"


### PR DESCRIPTION
This is related to https://github.com/michaeldexter/vmrc/pull/1. It may not be as robust as the other PR, but it does work for me with both img and zvol linux VMs. Basically it does not assume that a grub-style VM uses an .img disk.